### PR TITLE
Add cross-platform testing

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -55,14 +55,14 @@ jobs:
         with:
           exclude: .github/,.storybook/
 
-  coverage:
-    name: Update test coverage
+  test:
+    name: Test on ${{ matrix.os }}
     env:
       CI: true
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
         node-version: [20.x]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
@@ -84,15 +84,22 @@ jobs:
         shell: bash
         run: pnpm install --frozen-lockfile
 
+      - name: Run tests
+        if: ${{ matrix.os != 'ubuntu-latest' }}
+        run: pnpm test --run
+
       - name: Run tests with coverage
+        if: ${{ matrix.os == 'ubuntu-latest' }}
         run: pnpm coverage
+
       - name: Upload coverage
+        if: ${{ matrix.os == 'ubuntu-latest' }}
         uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
   build:
-    needs: [coverage, lint]
+    needs: [lint, test]
     name: Build
     env:
       CI: true

--- a/src/__tests__/discover-packages.test.ts
+++ b/src/__tests__/discover-packages.test.ts
@@ -1,3 +1,4 @@
+import path from "node:path";
 import * as manypkg from "@manypkg/get-packages";
 import {beforeEach, describe, expect, it, vi} from "vitest";
 import {discoverPackages} from "../discover-packages";
@@ -7,6 +8,10 @@ import {HandledError} from "../errors";
 vi.mock("@manypkg/get-packages", () => ({
     getPackages: vi.fn(),
 }));
+
+function normalizePathForComparison(filePath: string): string {
+    return filePath.replaceAll(path.sep, "/");
+}
 
 describe("discoverPackages", () => {
     beforeEach(() => {
@@ -77,7 +82,9 @@ describe("discoverPackages", () => {
         const result = await discoverPackages(workspaceRoot);
 
         // Assert
-        expect(result[0].path).toBe("/test/workspace/packages/test");
+        expect(normalizePathForComparison(result[0].path)).toBe(
+            "/test/workspace/packages/test",
+        );
     });
 
     it("should map package versions correctly", async () => {

--- a/src/__tests__/find-matching-bins.test.ts
+++ b/src/__tests__/find-matching-bins.test.ts
@@ -1,3 +1,4 @@
+import path from "node:path";
 import {beforeEach, describe, expect, it, vi} from "vitest";
 import type {PackageInfo} from "../discover-packages";
 import {findMatchingBins} from "../find-matching-bins";
@@ -8,6 +9,10 @@ vi.mock("node:fs/promises", () => ({
 }));
 
 import * as fs from "node:fs/promises";
+
+function normalizePathForComparison(filePath: string): string {
+    return filePath.replaceAll(path.sep, "/");
+}
 
 describe("findMatchingBins", () => {
     beforeEach(() => {
@@ -118,7 +123,9 @@ describe("findMatchingBins", () => {
         const matches = await findMatchingBins(packages, "x");
 
         // Assert
-        expect(matches[0].binPath).toBe("/test/path/dist/x.mjs");
+        expect(normalizePathForComparison(matches[0].binPath)).toBe(
+            "/test/path/dist/x.mjs",
+        );
     });
 
     it("should return empty array when no bins match", async () => {


### PR DESCRIPTION
## Summary:
This adds testing for macos and windows so that we can feel more sure that things work how we want. It's possible tests fail on windows. We will need to update the tests to be more cross-platform friendly once we see what those failures are.

Issue: XXX-XXXX

## Test plan:
Putting up the draft PR to see what the windows failures are. Once we know what those are, we can update the tests to be more cross-platform friendly and then we should be able to merge this in.