### PR TITLE
Ensure absolute path for auto completion

### DIFF
--- a/.changeset/silver-tools-drum.md
+++ b/.changeset/silver-tools-drum.md
@@ -1,0 +1,5 @@
+---
+"@somewhatabstract/x": patch
+---
+
+Make sure --completion output uses absolute path

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ pnpm add -g @somewhatabstract/x
 yarn global add @somewhatabstract/x
 ```
 
-When run from the global installation, `x` is invoked as just `x`. It will mimic the environment for the target script that it would run under if it had been unvoked via `npm exec` or equivalent.
+When run from the global installation, `x` is invoked as just `x`. It will mimic the environment for the target script that it would run under if it had been invoked via `npm exec` or equivalent.
 
 ### Local installation
 
@@ -72,12 +72,12 @@ This only executes bin scripts defined by packages in your workspace, not their 
 
 - 🔍 **Automatic Discovery**: Finds all packages in your monorepo workspace via @manypkg
 - 👁️ **Dry-Run Mode**: Preview what would be executed with `--dry-run`
-- 📦 **Multi-Package-Manager**: Works with npm, Yarn, pnpm, Lerna, Bun, and Rush, mimicing the npm-like environment.
+- 📦 **Multi-Package-Manager**: Works with npm, Yarn, pnpm, Lerna, Bun, and Rush, mimicking the npm-like environment.
 - ⌨️ **Auto-completion**: Shell autocompletion for available bin scripts
 
 ### Auto-completion
 
-`@somewhatabstract/x` can generate a shell completion script so you can tab-complete available bin scripts. It's best to use a global installation of `x` tab completion support since it will register the specific path to the `x` binary, which is necessary for the completion script to work correctly.
+`@somewhatabstract/x` can generate a shell completion script so you can tab-complete available bin scripts. It is recommended to use a global installation of `x` for tab completion support since it will register the specific path to the `x` binary invoked to add the support (which could be the one installed in a specific project when not using a global installation).
 
 With `@somewhatabstract/x` installed globally, add this to your shell configuration file (e.g. `~/.bashrc`, `~/.zshrc`, etc.):
 

--- a/README.md
+++ b/README.md
@@ -19,12 +19,36 @@ Execute bin scripts from monorepo packages without installing them at the root.
 
 Install `@somewhatabstract/x` globally, or as a dev dependency in your monorepo root package (you only need to install it once at the root of your workspace, not in each package).
 
+### Global installation
+
 ```bash
 npm install -g @somewhatabstract/x
 # or
 pnpm add -g @somewhatabstract/x
 # or
 yarn global add @somewhatabstract/x
+```
+
+When run from the global installation, `x` is invoked as just `x`. It will mimic the environment for the target script that it would run under if it had been unvoked via `npm exec` or equivalent.
+
+### Local installation
+
+```bash
+npm install -D @somewhatabstract/x
+# or
+pnpm add -D @somewhatabstract/x
+# or
+yarn add -D @somewhatabstract/x
+```
+
+When run from a local installation, `x` will execute the local version of `x` and use the package manager that was used to install it. To run the local version of `x`, use your package manager's exec command:
+
+```bash
+npm exec x <script-name> [-- <args...>]
+# or
+pnpm x <script-name> [-- <args...>]
+# or
+yarn x <script-name> [-- <args...>]
 ```
 
 ## Usage
@@ -48,33 +72,18 @@ This only executes bin scripts defined by packages in your workspace, not their 
 
 - 🔍 **Automatic Discovery**: Finds all packages in your monorepo workspace via @manypkg
 - 👁️ **Dry-Run Mode**: Preview what would be executed with `--dry-run`
-- 📦 **Multi-Package-Manager**: Works with npm, Yarn, pnpm, Lerna, Bun, and Rush
+- 📦 **Multi-Package-Manager**: Works with npm, Yarn, pnpm, Lerna, Bun, and Rush, mimicing the npm-like environment.
 - ⌨️ **Auto-completion**: Shell autocompletion for available bin scripts
 
 ### Auto-completion
 
-`x` can generate a shell completion script so you can tab-complete available bin scripts.
+`@somewhatabstract/x` can generate a shell completion script so you can tab-complete available bin scripts. It's best to use a global installation of `x` tab completion support since it will register the specific path to the `x` binary, which is necessary for the completion script to work correctly.
 
-If you have `x` installed globally, add this to your shell configuration file (e.g. `~/.bashrc`, `~/.zshrc`, etc.):
+With `@somewhatabstract/x` installed globally, add this to your shell configuration file (e.g. `~/.bashrc`, `~/.zshrc`, etc.):
 
 ```bash
 source <(x --completion)
 ```
-
-Or, if you prefer to use `x` without installing it globally, you can add this to your shell configuration file:
-
-```bash
-source <(npx @somewhatabstract/x --completion)
-```
-
-You can also write the completion script to a file and source it from there:
-
-```bash
-x --completion > ~/.x-completion.sh
-source ~/.x-completion.sh
-```
-
-If `x` is installed per-workspace rather than globally, source the completion script from the local installation instead.
 
 ## Development
 

--- a/src/__tests__/x.test.ts
+++ b/src/__tests__/x.test.ts
@@ -445,4 +445,47 @@ describe("bin/x", () => {
         // Assert
         expect(xImplMock).not.toHaveBeenCalled();
     });
+
+    describe("--completion script generation", () => {
+        let savedArgv: string[];
+
+        beforeEach(() => {
+            savedArgv = process.argv;
+            vi.spyOn(console, "log").mockImplementation(() => {});
+        });
+
+        afterEach(() => {
+            process.argv = savedArgv;
+        });
+
+        it("should embed the absolute module path in the completion script so it works from any directory", async () => {
+            // Arrange
+            process.argv = ["node", "x.mjs", "--completion"];
+
+            // Act
+            await main(["node", "x.mjs", "--completion"]).catch(() => {});
+
+            // Assert
+            const logOutput = vi
+                .mocked(console.log)
+                .mock.calls.flat()
+                .join("\n");
+            expect(logOutput).toMatch(/\/.*bin\/x.*--get-yargs-completions/);
+        });
+
+        it("should not use the absolute module path as the script name when not invoked as a completion request", async () => {
+            // Arrange
+            // process.argv does not include --completion
+
+            // Act
+            await main(["node", "x.mjs", "--completion"]).catch(() => {});
+
+            // Assert
+            const logOutput = vi
+                .mocked(console.log)
+                .mock.calls.flat()
+                .join("\n");
+            expect(logOutput).not.toMatch(/\/.*bin\/x.*--get-yargs-completions/);
+        });
+    });
 });

--- a/src/__tests__/x.test.ts
+++ b/src/__tests__/x.test.ts
@@ -475,10 +475,10 @@ describe("bin/x", () => {
 
         it("should not use the absolute module path as the script name when not invoked as a completion request", async () => {
             // Arrange
-            // process.argv does not include --completion
+            process.argv = ["node", "x.mjs"];
 
             // Act
-            await main(["node", "x.mjs", "--completion"]).catch(() => {});
+            await main(["node", "x.mjs"]).catch(() => {});
 
             // Assert
             const logOutput = vi

--- a/src/__tests__/x.test.ts
+++ b/src/__tests__/x.test.ts
@@ -485,7 +485,9 @@ describe("bin/x", () => {
                 .mocked(console.log)
                 .mock.calls.flat()
                 .join("\n");
-            expect(logOutput).not.toMatch(/\/.*bin\/x.*--get-yargs-completions/);
+            expect(logOutput).not.toMatch(
+                /\/.*bin\/x.*--get-yargs-completions/,
+            );
         });
     });
 });

--- a/src/bin/x.ts
+++ b/src/bin/x.ts
@@ -93,7 +93,12 @@ export async function main(rawArgv: string[]): Promise<XResult> {
         // detect if they forgot to do that and warn them.
         .parserConfiguration({"unknown-options-as-args": true});
 
-    const argv = await yi.parse();
+    // Set the script name dynamically
+    // Use absolute path for completion generation, simple name for help/usage
+    const isCompletionRequest = process.argv.includes("--completion");
+    const argv = await (isCompletionRequest
+        ? yi.scriptName(fileURLToPath(import.meta.url)).parse()
+        : yi.parse());
 
     if (argv.help || argv.h) {
         outputHelpWithSplash(yi);


### PR DESCRIPTION
## Summary:
The default is to use a relative path for the script which means that the auto-complete won't function correctly if executed from a different directory. By using the absolute path to the script for the completion generation, we ensure that the auto-completion works regardless of the current working directory.