### PR TITLE
Fix path issue that prevents the release from running

### DIFF
--- a/.changeset/swift-schools-live.md
+++ b/.changeset/swift-schools-live.md
@@ -1,0 +1,5 @@
+---
+"@somewhatabstract/x": patch
+---
+
+Make sure that we resolve to realpaths when comparing file paths in module import

--- a/src/bin/x.ts
+++ b/src/bin/x.ts
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+import {realpathSync} from "node:fs";
 import {fileURLToPath} from "node:url";
 import yargs from "yargs";
 import {hideBin} from "yargs/helpers";
@@ -134,7 +135,7 @@ export async function main(rawArgv: string[]): Promise<XResult> {
 
 // Only run main if we aren't being imported as a module.
 /* v8 ignore start -- runtime-only CLI bootstrap */
-if (process.argv[1] === fileURLToPath(import.meta.url)) {
+if (realpathSync(process.argv[1]) === fileURLToPath(import.meta.url)) {
     main(process.argv)
         .then((result) => {
             process.exit(result.exitCode);


### PR DESCRIPTION
## Summary:
`pnpm` does symlink magic and that sometimes breaks the execution of the script.

This fixes that.