### PR TITLE
Use x for script name outside of direct invocation

### DIFF
--- a/.changeset/wicked-tigers-fry.md
+++ b/.changeset/wicked-tigers-fry.md
@@ -1,0 +1,5 @@
+---
+"@somewhatabstract/x": minor
+---
+
+Give a useful script name for installs. This uses `x` when invoked as `x` or via say `pnpm x`. This means the tab completion should work out-of-the-box for global installations.

--- a/README.md
+++ b/README.md
@@ -70,21 +70,22 @@ x my-script -- --flag value
 
 This only executes bin scripts defined by packages in your workspace, not bin scripts defined by their dependencies. The bin must be an executable file with a shebang (on Unix-like systems) or a directly runnable file (on Windows), or a JS script that can be executed with Node.js.
 
+> ![NOTE]
+> `x` must be installed (globally or locally) to be used. It cannot be used via `npx`, `pnpx`, etc. due to how those tools pass arguments which interferes with how `x` processes arguments. If you want to use `x` without installing it globally, install it as a dev dependency in your monorepo root package and run it via your package manager's exec command as shown above.
+
 ## Features
 
 - 🔍 **Automatic Discovery**: Finds all packages in your monorepo workspace via @manypkg
 - 👁️ **Dry-Run Mode**: Preview what would be executed with `--dry-run`
 - 📦 **Multi-Package-Manager**: Works with npm, Yarn, pnpm, Lerna, Bun, and Rush, mimicking the npm-like environment.
-- ⌨️ **Auto-completion**: Shell autocompletion for available bin scripts
+- ⌨️ **Tab completion**: Shell tab completion for available bin scripts
 
-### Auto-completion
+### Tab completion
 
-`@somewhatabstract/x` can generate a shell completion script so you can tab-complete available bin scripts.
-
-For example, with `@somewhatabstract/x` installed globally, use this to add tab completion to your current shell session:
+`@somewhatabstract/x` can generate a shell completion script so you can tab-complete available bin scripts. With `@somewhatabstract/x` installed globally, use this to add tab completion to your current shell session:
 
 ```bash
-source <(x --completion)
+. <(x --completion)
 ```
 
 ## Development

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ x my-script -- --flag value
 
 This only executes bin scripts defined by packages in your workspace, not bin scripts defined by their dependencies. The bin must be an executable file with a shebang (on Unix-like systems) or a directly runnable file (on Windows), or a JS script that can be executed with Node.js.
 
-> ![NOTE]
+> [!NOTE]
 > `x` must be installed (globally or locally) to be used. It cannot be used via `npx`, `pnpx`, etc. due to how those tools pass arguments which interferes with how `x` processes arguments. If you want to use `x` without installing it globally, install it as a dev dependency in your monorepo root package and run it via your package manager's exec command as shown above.
 
 ## Features

--- a/src/__tests__/x.test.ts
+++ b/src/__tests__/x.test.ts
@@ -445,4 +445,68 @@ describe("bin/x", () => {
         // Assert
         expect(xImplMock).not.toHaveBeenCalled();
     });
+
+    describe("completion script scriptName", () => {
+        const savedEnvUnderscore = process.env._;
+
+        beforeEach(() => {
+            vi.spyOn(console, "log").mockImplementation(() => {});
+        });
+
+        afterEach(() => {
+            if (savedEnvUnderscore === undefined) {
+                delete process.env._;
+            } else {
+                process.env._ = savedEnvUnderscore;
+            }
+        });
+
+        it("should register completion for 'x' when process.env._ is unset (globally installed)", async () => {
+            // Arrange
+            delete process.env._;
+
+            // Act
+            try {
+                await main(["node", "x.mjs", "--completion"]);
+            } catch {
+                // process.exit is mocked to throw in tests
+            }
+
+            // Assert
+            const output = vi.mocked(console.log).mock.calls.flat().join("\n");
+            expect(output).toMatch(/_x_yargs_completions x$/m);
+        });
+
+        it("should register completion for 'x' when invoked via another tool (process.env._ is not x.mjs)", async () => {
+            // Arrange
+            process.env._ = "/usr/local/bin/pnpm";
+
+            // Act
+            try {
+                await main(["node", "x.mjs", "--completion"]);
+            } catch {
+                // process.exit is mocked to throw in tests
+            }
+
+            // Assert
+            const output = vi.mocked(console.log).mock.calls.flat().join("\n");
+            expect(output).toMatch(/_x_yargs_completions x$/m);
+        });
+
+        it("should not register completion for 'x' when invoked directly as x.mjs (dev mode)", async () => {
+            // Arrange
+            process.env._ = "./dist/x.mjs";
+
+            // Act
+            try {
+                await main(["node", "x.mjs", "--completion"]);
+            } catch {
+                // process.exit is mocked to throw in tests
+            }
+
+            // Assert
+            const output = vi.mocked(console.log).mock.calls.flat().join("\n");
+            expect(output).not.toMatch(/_x_yargs_completions x$/m);
+        });
+    });
 });

--- a/src/bin/x.ts
+++ b/src/bin/x.ts
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 import {realpathSync} from "node:fs";
+import {basename} from "node:path";
 import {fileURLToPath} from "node:url";
 import yargs from "yargs";
 import {hideBin} from "yargs/helpers";
@@ -94,7 +95,14 @@ export async function main(rawArgv: string[]): Promise<XResult> {
         // detect if they forgot to do that and warn them.
         .parserConfiguration({"unknown-options-as-args": true});
 
-    const argv = await yi.parse();
+    // If we have a process.env._ and it doesn't end with `x.mjs`, then it's
+    // likely we were invoked by another tool like pnpm or node.
+    // We want the scriptname to reflect, as best we can, what the user
+    // invoked.
+    const argv =
+        process.env._ && basename(process.env._) === "x.mjs"
+            ? await yi.parse()
+            : await yi.scriptName("x").parse();
 
     if (argv.help || argv.h) {
         outputHelpWithSplash(yi);


### PR DESCRIPTION
## Summary:
We were letting yargs decide what to call the script and it usually included the script file. This is not what we want when we are installed. Instead, we just want to call it `x`.

This should mean that tab completion will work out-of-the-box for users who have installed the package globally.